### PR TITLE
Initialize $sum Variable to Prevent Laravel exception

### DIFF
--- a/src/validateSAID.php
+++ b/src/validateSAID.php
@@ -44,6 +44,8 @@ class validateSAID {
 		$type = substr ( $id, 0, 1 );
 		if($type != 2 && $type != 1 ) return false;
 
+		// Initialize $sum
+		$sum = 0;
 		for( $i = 0 ; $i<10 ; $i++ ) {
 			//echo "  $id <b>"."</b> -";
 			if ( $i % 2 == 0){


### PR DESCRIPTION
This pull request addresses a compatibility issue identified in our Laravel application running under PHP 8.2. Previously, the variable $sum was used without being initialized, which was permissible in older PHP versions (up to PHP 7.x), where it only triggered a notice if error reporting was set to include E_NOTICE. However, in PHP 8.2, using an uninitialized variable results in an error, which could disrupt application functionality.

Changes Made:
Initialized the $sum variable to 0 before its use in the loop.